### PR TITLE
Add ORACLE LongReadLen attribute support

### DIFF
--- a/lib/POE/Component/SimpleDBI/SubProcess.pm
+++ b/lib/POE/Component/SimpleDBI/SubProcess.pm
@@ -155,6 +155,9 @@ sub DB_CONNECT {
 
 					# AutoCommit our stuff?
 					'AutoCommit'	=>	$data->{'AUTO_COMMIT'},
+					
+					# Maximum LOB lenght (Oracle)
+					'LongReadLen'	=>	$data->{'LONG_READ_LEN'},
 				}
 			);
 


### PR DESCRIPTION
To avoid zero response of ORACLE LOB data, this commit add support of ORACLE LongReadLen parameter.
